### PR TITLE
docs(repo): add contributor playbook for agents 😅

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root package `sdk` exposes runtime config and handler registration; tests live alongside (`sdk_test.go`).
+- `http/` holds the HTTP capability client, benchmarks, and host-aware tests; `http/mock/` provides the high-level mock. Coverage artifacts may appear here but should be ignored.
+- `hostmock/` simulates waPC host calls for integration-style assertions.
+- CI, release, and automation configs reside under `.github/` and `.release-*`.
+
+## Build, Test, and Development Commands
+- `make build` — compiles each component (`http`, etc.) via their local Makefiles.
+- `make tests` — runs `go test -race -covermode=atomic` for all components and emits coverage reports.
+- `make benchmarks` — executes package benchmarks; use when tuning hot paths.
+- `make format` / `make lint` — apply gofmt/goimports/golines and run `golangci-lint`.
+- Per-package work: `make -C http tests`, `make -C http lint`, etc.
+
+## Coding Style & Naming Conventions
+- Go 1.24+: rely on `make format` to run `gofmt`, `goimports`, and `golines`; do not hand-format.
+- Use descriptive package-level names; keep short identifiers scoped to tight loops or helpers.
+- Follow sentinel error pattern (`ErrThing`) and wrap with `%w` when returning.
+
+## Testing Guidelines
+- Standard Go `testing` package with table-driven cases; include happy and error paths.
+- Prefer black-box assertions via mocks (`http/mock`, `hostmock`).
+- Benchmarks live in `*_benchmark_test.go`; keep them deterministic.
+- Ensure race detector and coverage succeed before opening a PR.
+
+## Commit & Pull Request Guidelines
+- Commit messages follow Conventional Commits (`type(scope): subject`), e.g., `fix(http): guard nil handler`.
+- Summaries should be imperative, lowercase start, and omit trailing periods.
+- PRs should describe behavior changes, reference related issues, and note testing (`make tests`, `make lint`).
+
+## Security & Configuration Tips
+- No network or secret-aware tests should run by default; rely on mocks.
+- Manage protobuf or waPC dependency bumps through Dependabot or curated PRs.


### PR DESCRIPTION
## Summary
Adds a concise AGENTS.md playbook so contributors can ramp up without spelunking the repo.

## Changes
- document project layout, key Make targets, and formatting expectations
- outline testing habits, commit/PR etiquette, and security tips for waPC development

## Rationale
Having a single reference keeps handoffs fast and reduces the "what does this button do" chatter during reviews.

## Risk & Impact
- Breaking changes: no
- Performance/Security: documentation-only; no runtime impact


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added AGENTS.md as a repository-wide guidance document. It centralizes project structure, per-package build/test/dev commands, formatting and naming conventions, coding standards, testing strategies, commit/PR guidelines, dependency management, and security tips. Applies across all packages. No code changes or public API modifications, and no impact on runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->